### PR TITLE
FYTA integration: Add separate entities for both default and user plant images

### DIFF
--- a/homeassistant/components/fyta/__init__.py
+++ b/homeassistant/components/fyta/__init__.py
@@ -17,7 +17,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.util.dt import async_get_time_zone
 
-from .const import CONF_EXPIRATION, CONF_USER_IMAGE
+from .const import CONF_EXPIRATION
 from .coordinator import FytaConfigEntry, FytaCoordinator
 
 _LOGGER = logging.getLogger(__name__)
@@ -52,14 +52,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: FytaConfigEntry) -> bool
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
-    entry.async_on_unload(entry.add_update_listener(update_listener))
-
     return True
-
-
-async def update_listener(hass: HomeAssistant, entry: FytaConfigEntry) -> None:
-    """Handle options update."""
-    await hass.config_entries.async_reload(entry.entry_id)
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: FytaConfigEntry) -> bool:
@@ -79,13 +72,6 @@ async def async_migrate_entry(
         return False
 
     if config_entry.version == 1:
-        if config_entry.minor_version == 2:
-            hass.config_entries.async_update_entry(
-                config_entry,
-                options={CONF_USER_IMAGE: False},
-                minor_version=3,
-                version=1,
-            )
         if config_entry.minor_version < 2:
             new = {**config_entry.data}
             fyta = FytaConnector(
@@ -100,8 +86,7 @@ async def async_migrate_entry(
             hass.config_entries.async_update_entry(
                 config_entry,
                 data=new,
-                options={CONF_USER_IMAGE: False},
-                minor_version=3,
+                minor_version=2,
                 version=1,
             )
 

--- a/homeassistant/components/fyta/config_flow.py
+++ b/homeassistant/components/fyta/config_flow.py
@@ -15,17 +15,15 @@ from fyta_cli.fyta_exceptions import (
 from fyta_cli.fyta_models import Credentials
 import voluptuous as vol
 
-from homeassistant.config_entries import ConfigFlow, ConfigFlowResult, OptionsFlow
+from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
 from homeassistant.const import CONF_ACCESS_TOKEN, CONF_PASSWORD, CONF_USERNAME
-from homeassistant.core import callback
 from homeassistant.helpers.selector import (
     TextSelector,
     TextSelectorConfig,
     TextSelectorType,
 )
 
-from .const import CONF_EXPIRATION, CONF_USER_IMAGE, DOMAIN
-from .coordinator import FytaConfigEntry
+from .const import CONF_EXPIRATION, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -54,14 +52,6 @@ class FytaConfigFlow(ConfigFlow, domain=DOMAIN):
     credentials: Credentials
     VERSION = 1
     MINOR_VERSION = 3
-
-    @staticmethod
-    @callback
-    def async_get_options_flow(
-        config_entry: FytaConfigEntry,
-    ) -> FytaOptionsFlowHandler:
-        """Get the options flow for this handler."""
-        return FytaOptionsFlowHandler()
 
     async def async_auth(self, user_input: Mapping[str, Any]) -> dict[str, str]:
         """Reusable Auth Helper."""
@@ -135,27 +125,4 @@ class FytaConfigFlow(ConfigFlow, domain=DOMAIN):
             step_id="reauth_confirm",
             data_schema=data_schema,
             errors=errors,
-        )
-
-
-class FytaOptionsFlowHandler(OptionsFlow):
-    """Handle a options flow for fyta."""
-
-    async def async_step_init(
-        self, user_input: dict[str, Any] | None = None
-    ) -> ConfigFlowResult:
-        """Manage the options."""
-        if user_input is not None:
-            return self.async_create_entry(data=user_input)
-
-        return self.async_show_form(
-            step_id="init",
-            data_schema=vol.Schema(
-                {
-                    vol.Required(
-                        CONF_USER_IMAGE,
-                        default=self.config_entry.options[CONF_USER_IMAGE],
-                    ): bool,
-                }
-            ),
         )

--- a/homeassistant/components/fyta/const.py
+++ b/homeassistant/components/fyta/const.py
@@ -2,4 +2,3 @@
 
 DOMAIN = "fyta"
 CONF_EXPIRATION = "expiration"
-CONF_USER_IMAGE = "user_image"

--- a/homeassistant/components/fyta/image.py
+++ b/homeassistant/components/fyta/image.py
@@ -88,7 +88,6 @@ class FytaPlantImageEntity(FytaPlantEntity, ImageEntity):
         super().__init__(coordinator, entry, description, plant_id)
         ImageEntity.__init__(self, coordinator.hass)
 
-        self._attr_name = None
         self._image_type = image_type
         # For backward compatibility, keep unique_id and entity_id for default image
         if image_type == "user":
@@ -96,9 +95,11 @@ class FytaPlantImageEntity(FytaPlantEntity, ImageEntity):
             self._attr_entity_id = (
                 f"image.{self.plant.name.lower().replace(' ', '_')}_user"
             )
+            self._attr_name = "User Image"
         else:
             self._attr_unique_id = f"{entry.entry_id}-{plant_id}-plant_image"
             # entity_id is auto-generated, but we keep the key as before
+            self._attr_name = "Plant Image"
 
     async def async_image(self) -> bytes | None:
         """Return bytes of image."""

--- a/homeassistant/components/fyta/image.py
+++ b/homeassistant/components/fyta/image.py
@@ -29,17 +29,43 @@ async def async_setup_entry(
     """Set up the FYTA plant images."""
     coordinator = entry.runtime_data
 
-    description = ImageEntityDescription(key="plant_image")
+    description_default = ImageEntityDescription(key="plant_image")
+    description_user = ImageEntityDescription(key="plant_image_user")
 
-    async_add_entities(
-        FytaPlantImageEntity(coordinator, entry, description, plant_id)
-        for plant_id in coordinator.fyta.plant_list
-        if plant_id in coordinator.data
-    )
+    entities = []
+    for plant_id in coordinator.fyta.plant_list:
+        if plant_id in coordinator.data:
+            entities.append(
+                FytaPlantImageEntity(
+                    coordinator,
+                    entry,
+                    description_default,
+                    plant_id,
+                    image_type="default",
+                )
+            )
+            entities.append(
+                FytaPlantImageEntity(
+                    coordinator, entry, description_user, plant_id, image_type="user"
+                )
+            )
+
+    async_add_entities(entities)
 
     def _async_add_new_device(plant_id: int) -> None:
         async_add_entities(
-            [FytaPlantImageEntity(coordinator, entry, description, plant_id)]
+            [
+                FytaPlantImageEntity(
+                    coordinator,
+                    entry,
+                    description_default,
+                    plant_id,
+                    image_type="default",
+                ),
+                FytaPlantImageEntity(
+                    coordinator, entry, description_user, plant_id, image_type="user"
+                ),
+            ]
         )
 
     coordinator.new_device_callbacks.append(_async_add_new_device)
@@ -56,18 +82,27 @@ class FytaPlantImageEntity(FytaPlantEntity, ImageEntity):
         entry: ConfigEntry,
         description: ImageEntityDescription,
         plant_id: int,
+        image_type: str = "default",  # "default" or "user"
     ) -> None:
         """Initiatlize Fyta Image entity."""
         super().__init__(coordinator, entry, description, plant_id)
         ImageEntity.__init__(self, coordinator.hass)
 
         self._attr_name = None
-        self._user_image: bool = coordinator.config_entry.options["user_image"]
+        self._image_type = image_type
+        # For backward compatibility, keep unique_id and entity_id for default image
+        if image_type == "user":
+            self._attr_unique_id = f"{entry.entry_id}-{plant_id}-{description.key}"
+            self._attr_entity_id = (
+                f"image.{self.plant.name.lower().replace(' ', '_')}_user"
+            )
+        else:
+            self._attr_unique_id = f"{entry.entry_id}-{plant_id}-plant_image"
+            # entity_id is auto-generated, but we keep the key as before
 
     async def async_image(self) -> bytes | None:
         """Return bytes of image."""
-
-        if self._user_image:
+        if self._image_type == "user":
             if self._cached_image is None:
                 response = await self.coordinator.fyta.get_plant_image(
                     self.plant.user_picture_path
@@ -87,7 +122,6 @@ class FytaPlantImageEntity(FytaPlantEntity, ImageEntity):
                 )
 
             return self._cached_image.content
-
         return await ImageEntity.async_image(self)
 
     @property
@@ -95,7 +129,7 @@ class FytaPlantImageEntity(FytaPlantEntity, ImageEntity):
         """Return the image_url for this plant."""
         url = (
             self.plant.user_picture_path
-            if self._user_image
+            if self._image_type == "user"
             else self.plant.plant_origin_path
         )
 

--- a/homeassistant/components/fyta/image.py
+++ b/homeassistant/components/fyta/image.py
@@ -90,15 +90,6 @@ class FytaPlantImageEntity(FytaPlantEntity, ImageEntity):
         super().__init__(coordinator, entry, description, plant_id)
         ImageEntity.__init__(self, coordinator.hass)
 
-        # For backward compatibility, keep unique_id and entity_id for default image
-        if description.key == "plant_image":
-            self._attr_unique_id = f"{entry.entry_id}-{plant_id}-plant_image"
-            # entity_id is auto-generated, but we keep the key as before
-        else:
-            self._attr_unique_id = f"{entry.entry_id}-{plant_id}-{description.key}"
-            self._attr_entity_id = (
-                f"image.{self.plant.name.lower().replace(' ', '_')}_user"
-            )
 
     async def async_image(self) -> bytes | None:
         """Return bytes of image."""

--- a/homeassistant/components/fyta/image.py
+++ b/homeassistant/components/fyta/image.py
@@ -2,8 +2,13 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
+from dataclasses import dataclass
 from datetime import datetime
 import logging
+from typing import Final
+
+from fyta_cli.fyta_models import Plant
 
 from homeassistant.components.image import (
     Image,
@@ -21,6 +26,28 @@ from .entity import FytaPlantEntity
 _LOGGER = logging.getLogger(__name__)
 
 
+@dataclass(frozen=True, kw_only=True)
+class FytaImageEntityDescription(ImageEntityDescription):
+    """Describes Fyta image entity."""
+
+    url_fn: Callable[[Plant], str]
+    name_key: str | None = None
+
+
+IMAGES: Final[list[FytaImageEntityDescription]] = [
+    FytaImageEntityDescription(
+        key="plant_image",
+        translation_key="plant_image",
+        url_fn=lambda plant: plant.plant_origin_path,
+    ),
+    FytaImageEntityDescription(
+        key="plant_image_user",
+        translation_key="plant_image_user",
+        url_fn=lambda plant: plant.user_picture_path,
+    ),
+]
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: FytaConfigEntry,
@@ -29,43 +56,20 @@ async def async_setup_entry(
     """Set up the FYTA plant images."""
     coordinator = entry.runtime_data
 
-    description_default = ImageEntityDescription(key="plant_image")
-    description_user = ImageEntityDescription(key="plant_image_user")
-
-    entities = []
+    entities: list[FytaPlantImageEntity] = []
     for plant_id in coordinator.fyta.plant_list:
         if plant_id in coordinator.data:
-            entities.append(
-                FytaPlantImageEntity(
-                    coordinator,
-                    entry,
-                    description_default,
-                    plant_id,
-                    image_type="default",
-                )
-            )
-            entities.append(
-                FytaPlantImageEntity(
-                    coordinator, entry, description_user, plant_id, image_type="user"
-                )
+            entities.extend(
+                FytaPlantImageEntity(coordinator, entry, description, plant_id)
+                for description in IMAGES
             )
 
     async_add_entities(entities)
 
     def _async_add_new_device(plant_id: int) -> None:
         async_add_entities(
-            [
-                FytaPlantImageEntity(
-                    coordinator,
-                    entry,
-                    description_default,
-                    plant_id,
-                    image_type="default",
-                ),
-                FytaPlantImageEntity(
-                    coordinator, entry, description_user, plant_id, image_type="user"
-                ),
-            ]
+            FytaPlantImageEntity(coordinator, entry, description, plant_id)
+            for description in IMAGES
         )
 
     coordinator.new_device_callbacks.append(_async_add_new_device)
@@ -74,36 +78,32 @@ async def async_setup_entry(
 class FytaPlantImageEntity(FytaPlantEntity, ImageEntity):
     """Represents a Fyta image."""
 
-    entity_description: ImageEntityDescription
+    entity_description: FytaImageEntityDescription
 
     def __init__(
         self,
         coordinator: FytaCoordinator,
         entry: ConfigEntry,
-        description: ImageEntityDescription,
+        description: FytaImageEntityDescription,
         plant_id: int,
-        image_type: str = "default",  # "default" or "user"
     ) -> None:
         """Initiatlize Fyta Image entity."""
         super().__init__(coordinator, entry, description, plant_id)
         ImageEntity.__init__(self, coordinator.hass)
 
-        self._image_type = image_type
         # For backward compatibility, keep unique_id and entity_id for default image
-        if image_type == "user":
+        if description.key == "plant_image":
+            self._attr_unique_id = f"{entry.entry_id}-{plant_id}-plant_image"
+            # entity_id is auto-generated, but we keep the key as before
+        else:
             self._attr_unique_id = f"{entry.entry_id}-{plant_id}-{description.key}"
             self._attr_entity_id = (
                 f"image.{self.plant.name.lower().replace(' ', '_')}_user"
             )
-            self._attr_name = "User Image"
-        else:
-            self._attr_unique_id = f"{entry.entry_id}-{plant_id}-plant_image"
-            # entity_id is auto-generated, but we keep the key as before
-            self._attr_name = "Plant Image"
 
     async def async_image(self) -> bytes | None:
         """Return bytes of image."""
-        if self._image_type == "user":
+        if self.entity_description.key == "plant_image_user":
             if self._cached_image is None:
                 response = await self.coordinator.fyta.get_plant_image(
                     self.plant.user_picture_path
@@ -128,11 +128,7 @@ class FytaPlantImageEntity(FytaPlantEntity, ImageEntity):
     @property
     def image_url(self) -> str:
         """Return the image_url for this plant."""
-        url = (
-            self.plant.user_picture_path
-            if self._image_type == "user"
-            else self.plant.plant_origin_path
-        )
+        url = self.entity_description.url_fn(self.plant)
 
         if url != self._attr_image_url:
             self._cached_image = None

--- a/homeassistant/components/fyta/image.py
+++ b/homeassistant/components/fyta/image.py
@@ -87,7 +87,7 @@ class FytaPlantImageEntity(FytaPlantEntity, ImageEntity):
         description: FytaImageEntityDescription,
         plant_id: int,
     ) -> None:
-        """Initiatlize Fyta Image entity."""
+        """Initialize Fyta Image entity."""
         super().__init__(coordinator, entry, description, plant_id)
         ImageEntity.__init__(self, coordinator.hass)
 

--- a/homeassistant/components/fyta/image.py
+++ b/homeassistant/components/fyta/image.py
@@ -56,13 +56,12 @@ async def async_setup_entry(
     """Set up the FYTA plant images."""
     coordinator = entry.runtime_data
 
-    entities: list[FytaPlantImageEntity] = []
-    for plant_id in coordinator.fyta.plant_list:
-        if plant_id in coordinator.data:
-            entities.extend(
-                FytaPlantImageEntity(coordinator, entry, description, plant_id)
-                for description in IMAGES
-            )
+    entities: list[FytaPlantImageEntity] = [
+      FytaPlantImageEntity(coordinator, entry, description, plant_id)
+      for plant_id in coordinator.fyta.plant_list
+      if plant_id in coordinator.data
+      for description in IMAGES
+    ]
 
     async_add_entities(entities)
 

--- a/homeassistant/components/fyta/strings.json
+++ b/homeassistant/components/fyta/strings.json
@@ -9,8 +9,8 @@
           "password": "[%key:common::config_flow::data::password%]"
         },
         "data_description": {
-          "username": "The email address to log in to your FYTA account.",
-          "password": "The password to log in to your FYTA account."
+          "username": "The email address to login to your FYTA account.",
+          "password": "The password to login to your FYTA account."
         }
       },
       "reauth_confirm": {
@@ -35,20 +35,6 @@
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
       "password_error": "Invalid password",
       "unknown": "[%key:common::config_flow::error::unknown%]"
-    }
-  },
-  "options": {
-    "step": {
-      "init": {
-        "title": "Configure FYTA",
-        "description": "Configure the FYTA integration",
-        "data": {
-          "user_image": "User image"
-        },
-        "data_description": {
-          "user_image": "Use the user image insteas of the generic plant image."
-        }
-      }
     }
   },
   "entity": {
@@ -93,9 +79,9 @@
         "state": {
           "no_data": "No data",
           "too_low": "Too low",
-          "low": "[%key:common::state::low%]",
+          "low": "Low",
           "perfect": "Perfect",
-          "high": "[%key:common::state::high%]",
+          "high": "High",
           "too_high": "Too high"
         }
       },
@@ -104,9 +90,9 @@
         "state": {
           "no_data": "[%key:component::fyta::entity::sensor::temperature_status::state::no_data%]",
           "too_low": "[%key:component::fyta::entity::sensor::temperature_status::state::too_low%]",
-          "low": "[%key:common::state::low%]",
+          "low": "[%key:component::fyta::entity::sensor::temperature_status::state::low%]",
           "perfect": "[%key:component::fyta::entity::sensor::temperature_status::state::perfect%]",
-          "high": "[%key:common::state::high%]",
+          "high": "[%key:component::fyta::entity::sensor::temperature_status::state::high%]",
           "too_high": "[%key:component::fyta::entity::sensor::temperature_status::state::too_high%]"
         }
       },
@@ -115,9 +101,9 @@
         "state": {
           "no_data": "[%key:component::fyta::entity::sensor::temperature_status::state::no_data%]",
           "too_low": "[%key:component::fyta::entity::sensor::temperature_status::state::too_low%]",
-          "low": "[%key:common::state::low%]",
+          "low": "[%key:component::fyta::entity::sensor::temperature_status::state::low%]",
           "perfect": "[%key:component::fyta::entity::sensor::temperature_status::state::perfect%]",
-          "high": "[%key:common::state::high%]",
+          "high": "[%key:component::fyta::entity::sensor::temperature_status::state::high%]",
           "too_high": "[%key:component::fyta::entity::sensor::temperature_status::state::too_high%]"
         }
       },
@@ -126,9 +112,9 @@
         "state": {
           "no_data": "[%key:component::fyta::entity::sensor::temperature_status::state::no_data%]",
           "too_low": "[%key:component::fyta::entity::sensor::temperature_status::state::too_low%]",
-          "low": "[%key:common::state::low%]",
+          "low": "[%key:component::fyta::entity::sensor::temperature_status::state::low%]",
           "perfect": "[%key:component::fyta::entity::sensor::temperature_status::state::perfect%]",
-          "high": "[%key:common::state::high%]",
+          "high": "[%key:component::fyta::entity::sensor::temperature_status::state::high%]",
           "too_high": "[%key:component::fyta::entity::sensor::temperature_status::state::too_high%]"
         }
       },
@@ -137,9 +123,9 @@
         "state": {
           "no_data": "[%key:component::fyta::entity::sensor::temperature_status::state::no_data%]",
           "too_low": "[%key:component::fyta::entity::sensor::temperature_status::state::too_low%]",
-          "low": "[%key:common::state::low%]",
+          "low": "[%key:component::fyta::entity::sensor::temperature_status::state::low%]",
           "perfect": "[%key:component::fyta::entity::sensor::temperature_status::state::perfect%]",
-          "high": "[%key:common::state::high%]",
+          "high": "[%key:component::fyta::entity::sensor::temperature_status::state::high%]",
           "too_high": "[%key:component::fyta::entity::sensor::temperature_status::state::too_high%]"
         }
       },

--- a/homeassistant/components/fyta/strings.json
+++ b/homeassistant/components/fyta/strings.json
@@ -9,8 +9,8 @@
           "password": "[%key:common::config_flow::data::password%]"
         },
         "data_description": {
-          "username": "The email address to login to your FYTA account.",
-          "password": "The password to login to your FYTA account."
+          "username": "The email address to log in to your FYTA account.",
+          "password": "The password to log in to your FYTA account."
         }
       },
       "reauth_confirm": {
@@ -61,6 +61,14 @@
         "name": "Sensor update available"
       }
     },
+    "image": {
+      "plant_image": {
+        "name": "Plant Image"
+      },
+      "plant_image_user": {
+        "name": "User Image"
+      }
+    },
     "sensor": {
       "scientific_name": {
         "name": "Scientific name"
@@ -79,9 +87,9 @@
         "state": {
           "no_data": "No data",
           "too_low": "Too low",
-          "low": "Low",
+          "low": "[%key:common::state::low%]",
           "perfect": "Perfect",
-          "high": "High",
+          "high": "[%key:common::state::high%]",
           "too_high": "Too high"
         }
       },
@@ -90,9 +98,9 @@
         "state": {
           "no_data": "[%key:component::fyta::entity::sensor::temperature_status::state::no_data%]",
           "too_low": "[%key:component::fyta::entity::sensor::temperature_status::state::too_low%]",
-          "low": "[%key:component::fyta::entity::sensor::temperature_status::state::low%]",
+          "low": "[%key:common::state::low%]",
           "perfect": "[%key:component::fyta::entity::sensor::temperature_status::state::perfect%]",
-          "high": "[%key:component::fyta::entity::sensor::temperature_status::state::high%]",
+          "high": "[%key:common::state::high%]",
           "too_high": "[%key:component::fyta::entity::sensor::temperature_status::state::too_high%]"
         }
       },
@@ -101,9 +109,9 @@
         "state": {
           "no_data": "[%key:component::fyta::entity::sensor::temperature_status::state::no_data%]",
           "too_low": "[%key:component::fyta::entity::sensor::temperature_status::state::too_low%]",
-          "low": "[%key:component::fyta::entity::sensor::temperature_status::state::low%]",
+          "low": "[%key:common::state::low%]",
           "perfect": "[%key:component::fyta::entity::sensor::temperature_status::state::perfect%]",
-          "high": "[%key:component::fyta::entity::sensor::temperature_status::state::high%]",
+          "high": "[%key:common::state::high%]",
           "too_high": "[%key:component::fyta::entity::sensor::temperature_status::state::too_high%]"
         }
       },
@@ -112,9 +120,9 @@
         "state": {
           "no_data": "[%key:component::fyta::entity::sensor::temperature_status::state::no_data%]",
           "too_low": "[%key:component::fyta::entity::sensor::temperature_status::state::too_low%]",
-          "low": "[%key:component::fyta::entity::sensor::temperature_status::state::low%]",
+          "low": "[%key:common::state::low%]",
           "perfect": "[%key:component::fyta::entity::sensor::temperature_status::state::perfect%]",
-          "high": "[%key:component::fyta::entity::sensor::temperature_status::state::high%]",
+          "high": "[%key:common::state::high%]",
           "too_high": "[%key:component::fyta::entity::sensor::temperature_status::state::too_high%]"
         }
       },
@@ -123,9 +131,9 @@
         "state": {
           "no_data": "[%key:component::fyta::entity::sensor::temperature_status::state::no_data%]",
           "too_low": "[%key:component::fyta::entity::sensor::temperature_status::state::too_low%]",
-          "low": "[%key:component::fyta::entity::sensor::temperature_status::state::low%]",
+          "low": "[%key:common::state::low%]",
           "perfect": "[%key:component::fyta::entity::sensor::temperature_status::state::perfect%]",
-          "high": "[%key:component::fyta::entity::sensor::temperature_status::state::high%]",
+          "high": "[%key:common::state::high%]",
           "too_high": "[%key:component::fyta::entity::sensor::temperature_status::state::too_high%]"
         }
       },

--- a/tests/components/fyta/conftest.py
+++ b/tests/components/fyta/conftest.py
@@ -7,11 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from fyta_cli.fyta_models import Credentials, Plant
 import pytest
 
-from homeassistant.components.fyta.const import (
-    CONF_EXPIRATION,
-    CONF_USER_IMAGE,
-    DOMAIN as FYTA_DOMAIN,
-)
+from homeassistant.components.fyta.const import CONF_EXPIRATION, DOMAIN as FYTA_DOMAIN
 from homeassistant.const import CONF_ACCESS_TOKEN, CONF_PASSWORD, CONF_USERNAME
 
 from .const import ACCESS_TOKEN, EXPIRATION, PASSWORD, USERNAME
@@ -31,7 +27,6 @@ def mock_config_entry() -> MockConfigEntry:
             CONF_ACCESS_TOKEN: ACCESS_TOKEN,
             CONF_EXPIRATION: EXPIRATION,
         },
-        options={CONF_USER_IMAGE: False},
         minor_version=3,
         entry_id="ce5f5431554d101905d31797e1232da8",
     )

--- a/tests/components/fyta/snapshots/test_diagnostics.ambr
+++ b/tests/components/fyta/snapshots/test_diagnostics.ambr
@@ -15,7 +15,6 @@
       'entry_id': 'ce5f5431554d101905d31797e1232da8',
       'minor_version': 3,
       'options': dict({
-        'user_image': False,
       }),
       'pref_disable_new_entities': False,
       'pref_disable_polling': False,

--- a/tests/components/fyta/snapshots/test_image.ambr
+++ b/tests/components/fyta/snapshots/test_image.ambr
@@ -28,7 +28,7 @@
     'platform': 'fyta',
     'previous_unique_id': None,
     'supported_features': 0,
-    'translation_key': None,
+    'translation_key': 'plant_image',
     'unique_id': 'ce5f5431554d101905d31797e1232da8-0-plant_image',
     'unit_of_measurement': None,
   })
@@ -77,7 +77,7 @@
     'platform': 'fyta',
     'previous_unique_id': None,
     'supported_features': 0,
-    'translation_key': None,
+    'translation_key': 'plant_image_user',
     'unique_id': 'ce5f5431554d101905d31797e1232da8-0-plant_image_user',
     'unit_of_measurement': None,
   })
@@ -126,7 +126,7 @@
     'platform': 'fyta',
     'previous_unique_id': None,
     'supported_features': 0,
-    'translation_key': None,
+    'translation_key': 'plant_image',
     'unique_id': 'ce5f5431554d101905d31797e1232da8-1-plant_image',
     'unit_of_measurement': None,
   })
@@ -175,7 +175,7 @@
     'platform': 'fyta',
     'previous_unique_id': None,
     'supported_features': 0,
-    'translation_key': None,
+    'translation_key': 'plant_image_user',
     'unique_id': 'ce5f5431554d101905d31797e1232da8-1-plant_image_user',
     'unit_of_measurement': None,
   })

--- a/tests/components/fyta/snapshots/test_image.ambr
+++ b/tests/components/fyta/snapshots/test_image.ambr
@@ -1,5 +1,5 @@
 # serializer version: 1
-# name: test_all_entities[image.gummibaum-entry]
+# name: test_all_entities[image.gummibaum_plant_image-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -12,7 +12,7 @@
     'disabled_by': None,
     'domain': 'image',
     'entity_category': None,
-    'entity_id': 'image.gummibaum',
+    'entity_id': 'image.gummibaum_plant_image',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -24,7 +24,7 @@
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': None,
+    'original_name': 'Plant Image',
     'platform': 'fyta',
     'previous_unique_id': None,
     'supported_features': 0,
@@ -33,22 +33,22 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_all_entities[image.gummibaum-state]
+# name: test_all_entities[image.gummibaum_plant_image-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'access_token': '1',
-      'entity_picture': '/api/image_proxy/image.gummibaum?token=1',
-      'friendly_name': 'Gummibaum',
+      'entity_picture': '/api/image_proxy/image.gummibaum_plant_image?token=1',
+      'friendly_name': 'Gummibaum Plant Image',
     }),
     'context': <ANY>,
-    'entity_id': 'image.gummibaum',
+    'entity_id': 'image.gummibaum_plant_image',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unknown',
   })
 # ---
-# name: test_all_entities[image.kakaobaum-entry]
+# name: test_all_entities[image.gummibaum_user_image-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -61,7 +61,7 @@
     'disabled_by': None,
     'domain': 'image',
     'entity_category': None,
-    'entity_id': 'image.kakaobaum',
+    'entity_id': 'image.gummibaum_user_image',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -73,7 +73,56 @@
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': None,
+    'original_name': 'User Image',
+    'platform': 'fyta',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'ce5f5431554d101905d31797e1232da8-0-plant_image_user',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[image.gummibaum_user_image-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'access_token': '1',
+      'entity_picture': '/api/image_proxy/image.gummibaum_user_image?token=1',
+      'friendly_name': 'Gummibaum User Image',
+    }),
+    'context': <ANY>,
+    'entity_id': 'image.gummibaum_user_image',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_all_entities[image.kakaobaum_plant_image-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'image',
+    'entity_category': None,
+    'entity_id': 'image.kakaobaum_plant_image',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Plant Image',
     'platform': 'fyta',
     'previous_unique_id': None,
     'supported_features': 0,
@@ -82,15 +131,64 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_all_entities[image.kakaobaum-state]
+# name: test_all_entities[image.kakaobaum_plant_image-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'access_token': '1',
-      'entity_picture': '/api/image_proxy/image.kakaobaum?token=1',
-      'friendly_name': 'Kakaobaum',
+      'entity_picture': '/api/image_proxy/image.kakaobaum_plant_image?token=1',
+      'friendly_name': 'Kakaobaum Plant Image',
     }),
     'context': <ANY>,
-    'entity_id': 'image.kakaobaum',
+    'entity_id': 'image.kakaobaum_plant_image',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_all_entities[image.kakaobaum_user_image-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'image',
+    'entity_category': None,
+    'entity_id': 'image.kakaobaum_user_image',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'User Image',
+    'platform': 'fyta',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'ce5f5431554d101905d31797e1232da8-1-plant_image_user',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[image.kakaobaum_user_image-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'access_token': '1',
+      'entity_picture': '/api/image_proxy/image.kakaobaum_user_image?token=1',
+      'friendly_name': 'Kakaobaum User Image',
+    }),
+    'context': <ANY>,
+    'entity_id': 'image.kakaobaum_user_image',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/components/fyta/test_config_flow.py
+++ b/tests/components/fyta/test_config_flow.py
@@ -10,18 +10,12 @@ from fyta_cli.fyta_exceptions import (
 import pytest
 
 from homeassistant import config_entries
-from homeassistant.components.fyta.const import CONF_EXPIRATION, CONF_USER_IMAGE, DOMAIN
-from homeassistant.const import (
-    CONF_ACCESS_TOKEN,
-    CONF_PASSWORD,
-    CONF_USERNAME,
-    Platform,
-)
+from homeassistant.components.fyta.const import CONF_EXPIRATION, DOMAIN
+from homeassistant.const import CONF_ACCESS_TOKEN, CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
 
-from . import setup_platform
 from .const import ACCESS_TOKEN, EXPIRATION, PASSWORD, USERNAME
 
 from tests.common import MockConfigEntry
@@ -228,29 +222,3 @@ async def test_dhcp_discovery(
     assert result["errors"] == {}
 
     await user_step(hass, result["flow_id"], mock_setup_entry)
-
-
-async def test_options_flow(
-    hass: HomeAssistant,
-    mock_fyta_connector: AsyncMock,
-    mock_config_entry: MockConfigEntry,
-) -> None:
-    """Test options flow works correctly."""
-    await setup_platform(hass, mock_config_entry, [Platform.SENSOR])
-
-    result = await hass.config_entries.options.async_init(mock_config_entry.entry_id)
-
-    assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "init"
-
-    result = await hass.config_entries.options.async_configure(
-        result["flow_id"],
-        user_input={
-            CONF_USER_IMAGE: True,
-        },
-    )
-
-    assert result["type"] is FlowResultType.CREATE_ENTRY
-    assert mock_config_entry.options == {
-        CONF_USER_IMAGE: True,
-    }

--- a/tests/components/fyta/test_init.py
+++ b/tests/components/fyta/test_init.py
@@ -150,7 +150,6 @@ async def test_migrate_config_entry_1(
     assert entry.data[CONF_PASSWORD] == PASSWORD
     assert entry.data[CONF_ACCESS_TOKEN] == ACCESS_TOKEN
     assert entry.data[CONF_EXPIRATION] == EXPIRATION
-    assert not entry.options
 
 
 async def test_migrate_config_entry_2(
@@ -180,4 +179,3 @@ async def test_migrate_config_entry_2(
 
     assert entry.version == 1
     assert entry.minor_version == 2
-    assert not entry.options

--- a/tests/components/fyta/test_init.py
+++ b/tests/components/fyta/test_init.py
@@ -10,7 +10,6 @@ from fyta_cli.fyta_exceptions import (
 )
 import pytest
 
-from homeassistant.components.fyta import CONF_USER_IMAGE
 from homeassistant.components.fyta.const import CONF_EXPIRATION, DOMAIN as FYTA_DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import (
@@ -146,12 +145,12 @@ async def test_migrate_config_entry_1(
     await hass.async_block_till_done()
 
     assert entry.version == 1
-    assert entry.minor_version == 3
+    assert entry.minor_version == 2
     assert entry.data[CONF_USERNAME] == USERNAME
     assert entry.data[CONF_PASSWORD] == PASSWORD
     assert entry.data[CONF_ACCESS_TOKEN] == ACCESS_TOKEN
     assert entry.data[CONF_EXPIRATION] == EXPIRATION
-    assert not entry.options[CONF_USER_IMAGE]
+    assert not entry.options
 
 
 async def test_migrate_config_entry_2(
@@ -180,5 +179,5 @@ async def test_migrate_config_entry_2(
     await hass.async_block_till_done()
 
     assert entry.version == 1
-    assert entry.minor_version == 3
-    assert not entry.options[CONF_USER_IMAGE]
+    assert entry.minor_version == 2
+    assert not entry.options


### PR DESCRIPTION
Proposed change
This PR enhances the FYTA integration to automatically create two image entities for each plant:
The default plant image (with original entity ID preserved for backward compatibility)
The user-uploaded plant image (with a "user" suffix added to the entity ID)
Instead of forcing users to choose which image type to display via an options menu, this approach provides both images as separate entities, giving users more flexibility in dashboard displays and automations. Users can now use both images simultaneously in their UI.

Type of change
[x] New feature (which adds functionality to an existing integration)

Additional information
This PR is related to issue: N/A
Link to documentation pull request: N/A

Checklist
[x] The code change is tested and works locally.
[  ] Local tests pass.
[x] There is no commented out code in this PR.
[x] I have followed the [development checklist][dev-checklist]
[x] Tests have been updated to verify that the new code works.

To help with the load of incoming pull requests:
[ ] I have reviewed two other [open pull requests][prs] in this repository.